### PR TITLE
Adds "Delete Unused Tags" button to admin/tags view

### DIFF
--- a/AdminToolsPlugin.php
+++ b/AdminToolsPlugin.php
@@ -30,7 +30,8 @@
 			'public_head',
 			'public_footer',
 			'neatline_public_static',
-			'define_acl'
+			'define_acl',
+			'admin_tags_browse'
 		);
 
 		protected $_filters = array(
@@ -352,6 +353,23 @@
 			);
 			$navLinks[] = $element;
 			return array_merge($navLinks, $lastLink);
+		}
+		
+		/**
+		 * Adds button to delete empty tags from admin/tags
+		 */
+		public function hookAdminTagsBrowse($args, $deleted=0, $html=null)
+		{
+			if(!$args || !isset($args['tags'])) return;
+			include_once(__DIR__.'/views/admin/css/admin-tags-browse.css');
+			include_once(__DIR__.'/views/admin/javascripts/admin-tags-browse.js'); 
+			$html .= '<form class="det hidden" action="'.url('admin-tools/index/delete-tags-browse').'">';
+				$html .= '<h2>'.__('Maintenance').'</h2>';
+				$html .= '<p>'.__('Delete all tags that have no correspondence with any record.').'</p>';
+				$html .= '<input type="hidden" name="delete-empty-tags" value="true"/>';
+				$html .= '<button class="big red button" type="submit">'.__('Delete Unused Tags').'</button>';
+			$html .= '</form>';
+			echo $html;
 		}
 	}
 ?>

--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -94,13 +94,22 @@
 		
 		public function deleteTagsAction()
 		{
+			$this->_deleteUnusedTags();
+			$this->_helper->redirector('index', 'index');
+		}
+		
+		public function deleteTagsBrowseAction()
+		{
+			$this->_deleteUnusedTags();
+			$this->_helper->redirector('browse','tags','');
+		}
+		
+		private function _deleteUnusedTags()
+		{
 			$db = get_db();
 			$query = 'DELETE FROM ' . $db->getTableName('Tag') . ' WHERE id IN (SELECT t.id FROM ' . $db->getTableName('Tag') . ' t LEFT outer join ' . $db->getTableName('RecordsTag') . ' rt ON t.id = rt.tag_id GROUP BY name HAVING count(rt.id) = 0)';
 			$db->query($query);
-
 			$this->_helper->flashMessenger(__('All unused tags have been deleted.'), 'success');
-			
-			$this->_helper->redirector('index', 'index');
 		}
 			
 		private function _getLastBackupDateTime()

--- a/views/admin/css/admin-tags-browse.css
+++ b/views/admin/css/admin-tags-browse.css
@@ -1,0 +1,19 @@
+<style>
+	form.det.hidden
+	form.det .hidden{
+		visibility: hidden;
+		display: none;
+	}
+	form.det button{
+		width: 100%;
+	}
+	form.det button::before{
+		content: "\f2ed";
+		font-family: "Font Awesome 5 Free";
+		display: inline;
+		padding-right: .5em;
+	}
+	#flash ul li.det{
+		background-color: lightyellow !important;
+	}
+</style>

--- a/views/admin/javascripts/admin-tags-browse.js
+++ b/views/admin/javascripts/admin-tags-browse.js
@@ -1,0 +1,13 @@
+<script>
+	document.addEventListener("DOMContentLoaded", () => {
+		let section = document.querySelector('.content-wrapper section:first-of-type');
+		let form = document.querySelector('form.det');
+		if(section && form){
+			// move button to preferred location and unhide
+			section.appendChild(form);
+			form.classList.remove('hidden');
+		}else{
+			console.warn('Delete Empty Tags: Unable to find required elements in DOM tree.');
+		}
+	});
+</script>


### PR DESCRIPTION
Per your [message on the Omeka Forum](https://forum.omeka.org/t/delete-empty-tags/26996), here's a PR that adds the "Delete Unused Tags" button to the `admin/tags` view. A couple things worth noting:
- Where possible/appropriate, I mirrored/repurposed the language that was already in use in the Admin Tools plugin, i.e. "unused tags" rather than "empty tags," etc. 
- I discarded my own script for  actually deleting the tags, which was limited to deleting just the tags rendered in the current view. Instead, I adapted your existing code, breaking out the relevant script into a standalone function to keep it DRY, i.e. `_deleteUnusedTags()`.
- There appears to be an issue with that function, as it does result in an error, at least in my environment. This was the case prior to this commit. Not entirely sure what is the problem, but I suppose it should be handled in a separate commit or PR. I'll provide more details separately.
