### PR TITLE
fix jQuery tabs on config

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -4,8 +4,7 @@
 ?>
 
 <?php echo js_tag('vendor/tinymce/tinymce.min'); ?>
-
-<script type="text/javascript" src="/omeka/admin/themes/default/javascripts/tabs.js?v=3.0.3" charset="utf-8"></script>
+<?php echo js_tag('tabs'); ?>
 
 <script type="text/javascript">
 	jQuery(document).ready(function () {


### PR DESCRIPTION
Simple fix here. The script `src` attribute started with `/omeka/` so the tabs script was failing to load. 